### PR TITLE
Clean up to allow build on modern gcc/Linux

### DIFF
--- a/clink.h
+++ b/clink.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/time.h>
@@ -18,6 +19,7 @@
 #include <sys/un.h>
 #include <stdarg.h>
 #include <syslog.h>
+#include <unistd.h>
 
 /* maximum message size */
 #define MAX_SIZE 3000

--- a/collect.h
+++ b/collect.h
@@ -1,0 +1,3 @@
+#pragma once
+void clink_init (char *host, int tos);
+int send_probe (int size, int ttl, int timeout, Datum *datum);

--- a/process.c
+++ b/process.c
@@ -1,4 +1,6 @@
 #include "clink.h"
+#include "util.h"
+#include "collect.h"
 #include <math.h>
 #include <assert.h>
 
@@ -29,6 +31,7 @@ int probe_count;     /* how many probes have we sent to this link so far? */
 
 int num_fiddles;     /* how many times we fiddle with the data */
 
+int send_one_probe (int size, int ttl);
 /* paths: the big, hairy data structure that contains all the data
           we've collected.  paths is an array of Path structures;
 	  each one contains alternate paths, but at the end we only
@@ -982,7 +985,7 @@ int fiddle_link (Link *link)
   int i, ret;
   int n = 0;
 
-  if (link == NULL) return;
+  if (link == NULL) return -1;
 
   /* get more data for any size with a positive residual */
   process_link (link);
@@ -1348,7 +1351,7 @@ void clink_loop ()
 
 /* main: process the options and call the appropriate procedures */
 
-main (int argc, char *argv[])
+int main (int argc, char *argv[])
 {
   int i, c;
 

--- a/util.c
+++ b/util.c
@@ -1,4 +1,4 @@
-#include "clink.h"
+#include "util.h"
 
 /* the vast majority of the following are taken directly from
    the library of procedures Stevens presents in UNIX Network
@@ -9,7 +9,6 @@
 
 */
 
-#define MAXLINE 4096
 
 void err_doit (int errnoflag, int level, const char *fmt, va_list ap)
 {

--- a/util.h
+++ b/util.h
@@ -1,0 +1,32 @@
+#include "clink.h"
+#include <unistd.h>
+
+#define MAXLINE 4096
+
+void err_doit (int errnoflag, int level, const char *fmt, va_list ap);;
+void err_sys (char *fmt, ...);;
+void err_quit (char *fmt, ...);
+void err_msg (char *fmt, ...);
+char *sock_ntop_host(const struct sockaddr *sa, socklen_t salen);
+char *Sock_ntop_host(const struct sockaddr *sa, socklen_t salen);
+void sock_set_port(struct sockaddr *sa, socklen_t salen, int port);
+int sock_cmp_addr(const struct sockaddr *sa1, const struct sockaddr *sa2,socklen_t salen);
+void tv_sub (struct timeval *out, struct timeval *in);
+char *icmpcode_v4(int code);
+Sigfunc *signal(int signo, Sigfunc *func);
+Sigfunc *Signal(int signo, Sigfunc *func)	/* for our signal() function */;
+void *Malloc(size_t size);
+void *Calloc(size_t n, size_t size);
+void Gettimeofday(struct timeval *tv, void *foo);
+void Pipe(int *fds);
+void Bind(int fd, const struct sockaddr *sa, socklen_t salen);
+void Setsockopt(int fd, int level, int optname, const void *optval,		socklen_t optlen);
+struct addrinfo *host_serv (char *host, char *serv, int family, int socktype);
+struct addrinfo *Host_serv(const char *host, const char *serv, int family, int socktype);
+ssize_t Read(int fd, void *ptr, size_t nbytes);
+void Write(int fd, void *ptr, size_t nbytes);
+ssize_t Recvfrom(int fd, void *ptr, size_t nbytes, int flags,		 struct sockaddr *sa, socklen_t *salenptr);
+int Socket(int family, int type, int protocol);
+void Sendto(int fd, const void *ptr, size_t nbytes, int flags,	   const struct sockaddr *sa, socklen_t salen);
+int convert_sockaddr (char *ip_addr, Sockaddr_in *addr, socklen_t salen);
+void microsleep (int usecs);


### PR DESCRIPTION
The repository as it exists does not build cleanly on a modern Linux setup (Ubuntu 18.04, x86_64); it dumps a bunch of implicit symbol warnings and ends up segfaulting on execution.

Adding a few declarations and header includes solves the problem!